### PR TITLE
 Update rest-api.md to upstream at 2018-10-04

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -1963,7 +1963,7 @@ Output:
  * 説明: コンテナの状態を変更する <!-- Description: change the container state -->
  * 認証: trusted <!-- Authentication: trusted -->
  * 操作: 非同期 <!-- Operation: async -->
- * 戻り値: 現在の状態を表す dict <!-- Return: dict representing current state -->
+ * 戻り値: バックグラウンド操作または標準のエラー <!-- Return: background operation or standard error -->
 
 入力
 <!--


### PR DESCRIPTION
[1個めのコミット](https://github.com/lxc-jp/lxd-ja/commit/1dbc57c289658eca4a7fe38a0767eb97ff5dc32a) が upstream の翻訳更新分です。

[2個めのコミット](https://github.com/lxc-jp/lxd-ja/commit/8c6eb5eb62f5f91680872e3f65ca90a9708bb3a1) ですが https://github.com/lxc-jp/lxd-ja/pull/42#issuecomment-423184045 のコメントを再確認してみたところ私の勘違いでした。すみません。
https://github.com/lxc/lxd/blame/13baa41f6258e91710c035ea4391e8b8a889a2b2/doc/rest-api.md#L1244 のように `PUT /1.0/containers/<name>/state` は2年前から操作は非同期で戻り値はバックグラウンド操作または標準のエラーになっていました。
ということで、この修正も合わせて入れています。

もしプルリクエストを分けたほうが良ければそうしますので、気軽に言ってください。