### PR TITLE
Update translations of LXD 4.22 (Closes #212)

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2913,3 +2913,56 @@ Ceph ストレージブールに `ceph.rbd.du` という boolean の設定を追
 Adds a new `ceph.rbd.du` boolean on Ceph storage pools which allows
 disabling the use of the potentially slow `rbd du` calls.
 -->
+
+## instance\_get\_full
+これは `GET /1.0/instances/{name}` に recursion=1 のモードを追加します。
+これは状態、スナップショット、バックアップの構造体を含む全てのインスタンスの構造体が取得できます。
+<!--
+This introduces a new recursion=1 mode for `GET /1.0/instances/{name}` which allows for the retrieval of
+all instance structs, including the state, snapshots and backup structs.
+-->
+
+## qemu\_metrics
+これは `security.agent.metrics` という boolean 値を追加します。デフォルト値は `true` です。
+`false` に設定するとメトリクスや他の状態の取得のために lxd-agent に接続することはせず、 QEMU からの統計情報に頼ります。
+<!--
+This adds a new `security.agent.metrics` boolean which defaults to `true`.
+When set to `false`, it doesn't connect to the lxd-agent for metrics and other state information, but relies on stats from QEMU.
+-->
+
+## gpu\_mig\_uuid
+Nvidia `470+` ドライバー (例. `MIG-74c6a31a-fde5-5c61-973b-70e12346c202`) で使用される MIG UUID 形式のサポートを追加します。
+`MIG-` の接頭辞は省略できます。
+<!--
+Adds support for the new MIG UUID format used by Nvidia `470+` drivers (eg. `MIG-74c6a31a-fde5-5c61-973b-70e12346c202`),
+the `MIG-` prefix can be omitted
+-->
+
+この拡張が古い `mig.gi` と `mig.ci` パラメーターに取って代わります。これらは古いドライバーとの互換性のため残されますが、
+同時には設定できません。
+<!--
+This extension supersedes old `mig.gi` and `mig.ci` parameters which are kept for compatibility with old drivers and
+cannot be set together.
+-->
+
+## event\_project
+イベントの API にイベントが属するプロジェクトを公開します。
+<!--
+Expose the project an API event belongs to.
+-->
+
+## clustering\_evacuation\_live
+`cluster.evacuate` への設定値 `live-migrate` を追加します。
+これはクラスター待避の際にインスタンスのライブマイグレーションを強制します。
+<!--
+This adds `live-migrate` as a config option to `cluster.evacuate`, which forces live-migration
+of instances during cluster evacuation.
+-->
+
+## instance\_allow\_inconsistent\_copy
+`POST /1.0/instances` のインスタンスソースに `allow_inconsistent` フィールドを追加します。
+true の場合、 rsync はコピーからインスタンスを生成するときに `Partial transfer due to vanished source files` (code 24) エラーを無視します。
+<!--
+Adds `allow_inconsistent` field to instance source on `POST /1.0/instances`. If true, rsync will ignore the 
+`Partial transfer due to vanished source files` (code 24) error when creating an instance from a copy. 
+-->

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -3,7 +3,7 @@
 <!--
 Current LXD stores configurations for a few components:
 -->
-現在 LXD はいくつかのコンポーネントの設定を保管しています。
+LXD は次のコンポーネントの設定を保管しています。
 
 - [サーバ](server.md) <!--[Server](server.md) -->
 - [インスタンス](instances.md)  <!-- [Instances](instances.md) -->

--- a/doc/doc-cheat-sheet.md
+++ b/doc/doc-cheat-sheet.md
@@ -481,22 +481,22 @@ By combining file inclusion and substitutions, you can even replace parts of the
 * - Input
   - Output
 * - ````
-    % Include parts of the content from file [architectures.md](architectures.md)
-    ```{include} architectures.md
-       :start-after: Introduction
-       :end-before: Please note that what LXD cares about
+    % Include parts of the content from file [../README.md](../README.md)
+    ```{include} ../README.md
+       :start-after: Installing LXD from packages
+       :end-before: <!-- Include end installing -->
     ```
     ````
-  - % Include parts of the content from file [architectures.md](architectures.md)
-    ```{include} architectures.md
-       :start-after: Introduction
-       :end-before: Please note that what LXD cares about
+  - % Include parts of the content from file [../README.md](../README.md)
+    ```{include} ../README.md
+       :start-after: Installing LXD from packages
+       :end-before: <!-- Include end installing -->
     ```
 `````
 
 Adhere to the following convention:
 - File inclusion does not work on GitHub. Therefore, always add a comment linking to the included file.
-- To select parts of the text, use `:start-after:` and `:end-before:` if possible. You can combine those with `:start-line:` and `:end-line:` if required (if the same text occurs more than once). Using only `:start-line:` and `:end-line:` is error-prone though.
+- To select parts of the text, add HTML comments for the start and end points and use `:start-after:` and `:end-before:`, if possible. You can combine `:start-after:` and `:end-before:` with `:start-line:` and `:end-line:` if required. Using only `:start-line:` and `:end-line:` is error-prone though.
 
 ## Tabs
 

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -1,17 +1,17 @@
 # LXD のインストール <!-- Installing LXD -->
 
-LXD をインストールする最も簡単な方法は [Getting started guide](https://linuxcontainers.org/lxd/getting-started-cli/#installing-a-package) で説明されているパッケージのどれかをインストールすることですが、ソースから LXD をインストールすることもできます。
+LXD をインストールする最も簡単な方法は提供されているパッケージのどれかをインストールすることですが、ソースから LXD をインストールすることもできます。
 <!--
-The easiest way to install LXD is to install one of the available packages as described in the [Getting started guide](https://linuxcontainers.org/lxd/getting-started-cli/#installing-a-package), but you can also install LXD from the sources.
+The easiest way to install LXD is to install one of the available packages, but you can also install LXD from the sources.
 -->
 
 ## LXD のソースからのインストール <!-- Installing LXD from source -->
-LXD の開発には liblxc の最新バージョン（3.0.0 以上が必要）を使用することをおすすめします。
-さらに LXD が動作するためには Golang 1.13 以上が必要です。
+LXD の開発には liblxc の最新バージョン（4.0.0 以上が必要）を使用することをおすすめします。
+さらに LXD が動作するためには Golang 1.16 以上が必要です。
 Ubuntu では次のようにインストールできます:
 <!--
-We recommend having the latest versions of liblxc (>= 3.0.0 required)
-available for LXD development. Additionally, LXD requires Golang 1.13 or
+We recommend having the latest versions of liblxc (>= 4.0.0 required)
+available for LXD development. Additionally, LXD requires Golang 1.16 or
 later to work. On ubuntu, you can get those with:
 -->
 

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -66,7 +66,7 @@ boot.stop.priority                          | integer   | 0                     
 cloud-init.network-config                   | string    | eth0 上の DHCP <!-- DHCP on eth0 --> | no            | -                         | Cloud-init network-config。設定はシード値として使用 <!-- Cloud-init network-config, content is used as seed value -->
 cloud-init.user-data                        | string    | #cloud-config                        | no            | -                         | Cloud-init user-data。設定はシード値として使用 <!-- Cloud-init user-data, content is used as seed value -->
 cloud-init.vendor-data                      | string    | #cloud-config                        | no            | -                         | Cloud-init vendor-data。設定はシード値として使用 <!-- Cloud-init vendor-data, content is used as seed value -->
-cluster.evacuate                            | string    | auto                                 | n/a           | -                         | インスタンス待避時に何をするか（auto, migrate, stop） <!-- What to do when evacuating the instance (auto, migrate, or stop) -->
+cluster.evacuate                            | string    | auto                                 | n/a           | -                         | インスタンス待避時に何をするか（auto, migrate, live-migrate, stop） <!-- What to do when evacuating the instance (auto, migrate, live-migrate, or stop) -->
 environment.\*                              | string    | -                                    | yes (exec)    | -                         | インスタンス実行時に設定される key/value 形式の環境変数<!-- key/value environment variables to export to the instance and set on exec -->
 limits.cpu                                  | string    | -                                    | yes           | -                         | インスタンスに割り当てる CPU 番号、もしくは番号の範囲（デフォルトは VM 毎に 1 CPU） <!-- Number or range of CPUs to expose to the instance (defaults to 1 CPU for VMs) -->
 limits.cpu.allowance                        | string    | 100%                                 | yes           | container                 | どれくらい CPU を使えるか。ソフトリミットとしてパーセント指定（例、50%）か固定値として単位時間内に使える時間（25ms/100ms）を指定できます <!-- How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms) -->
@@ -108,6 +108,7 @@ security.nesting                            | boolean   | false                 
 security.privileged                         | boolean   | false                                | no            | container                 | 特権モードでインスタンスを実行するかどうか <!--Runs the instance in privileged mode -->
 security.protection.delete                  | boolean   | false                                | yes           | -                         | インスタンスを削除から保護する <!-- Prevents the instance from being deleted -->
 security.protection.shift                   | boolean   | false                                | yes           | container                 | インスタンスのファイルシステムが起動時に uid/gid がシフト（再マッピング） されるのを防ぐ <!-- Prevents the instance's filesystem from being uid/gid shifted on startup -->
+security.agent.metrics                      | boolean   | true                                 | no            | virtual-machine           | 状態の情報とメトリクスを lxd-agent に問い合わせるかどうかを制御する <!-- Controls whether the lxd-agent is queried for state information and metrics -->
 security.secureboot                         | boolean   | true                                 | no            | virtual-machine           | UEFI セキュアブートがデフォルトの Microsoft のキーで有効になるかを制御する <!-- Controls whether UEFI secure boot is enabled with the default Microsoft keys -->
 security.syscalls.allow                     | string    | -                                    | no            | container                 | `\n` 区切りのシステムコールの許可リスト（security.syscalls.deny\* を使う場合は使用不可）  <!-- A '\n' separated list of syscalls to allow (mutually exclusive with security.syscalls.deny\*) -->
 security.syscalls.deny                      | string    | -                                    | no            | container                 | `\n` 区切りのシステムコールの拒否リスト <!-- A '\n' separated list of syscalls to deny -->
@@ -1393,8 +1394,14 @@ vendorid    | string    | -                 | no        | GPU デバイスのベ
 productid   | string    | -                 | no        | GPU デバイスのプロダクト ID <!-- The product id of the GPU device -->
 id          | string    | -                 | no        | GPU デバイスのカード ID <!-- The card id of the GPU device -->
 pci         | string    | -                 | no        | GPU デバイスの PCI アドレス <!-- The pci address of the GPU device -->
-mig.ci      | int       | -                 | yes       | 既存の MIG コンピュートインスタンス ID <!-- Existing MIG compute instance ID -->
-mig.gi      | int       | -                 | yes       | 既存の MIG GPU インスタンス ID <!-- Existing MIG GPU instance ID -->
+mig.ci      | int       | -                 | no        | 既存の MIG コンピュートインスタンス ID <!-- Existing MIG compute instance ID -->
+mig.gi      | int       | -                 | no        | 既存の MIG GPU インスタンス ID <!-- Existing MIG GPU instance ID -->
+mig.uuid    | string    | -                 | no        | 既存の MIG デバイス UUID ("MIG-" 接頭辞は省略可) <!-- Existing MIG device UUID ("MIG-" prefix can be omitted) -->
+
+注意: "mig.uuid" (Nvidia drivers 470+) か、 "mig.ci" と  "mig.gi" (古い Nvidia ドライバー) の両方を設定する必要があります。
+<!--
+Note: Either "mig.uuid" (Nvidia drivers 470+) or both "mig.ci" and "mig.gi" (old Nvidia drivers) must be set.
+-->
 
 ##### gpu: sriov
 

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -3,9 +3,9 @@
 ## Go
 
 <!--
-LXD requires Go 1.13 or higher and is only tested with the golang compiler.
+LXD requires Go 1.16 or higher and is only tested with the golang compiler.
 -->
-LXD は Go 1.13 以上を必要とし、 golang のコンパイラのみでテストされています。
+LXD は Go 1.16 以上を必要とし、 golang のコンパイラのみでテストされています。
 (訳注: 以前は gccgo もサポートされていましたが golang のみになりました)
 
 ビルドには最低 2GB の RAM を推奨します。
@@ -15,9 +15,9 @@ We recommend having at least 2GB of RAM to allow the build to complete.
 
 ## 必要なカーネルバージョン <!-- Kernel requirements -->
 <!--
-The minimum supported kernel version is 3.13.
+The minimum supported kernel version is 5.4
 -->
-サポートされる最小のカーネルバージョンは 3.13 です。
+サポートされる最小のカーネルバージョンは 5.4 です。
 
 <!--
 LXD requires a kernel with support for:
@@ -55,9 +55,9 @@ As well as any other kernel feature required by the LXC version in use.
 
 ## LXC
 <!--
-LXD requires LXC 3.0.0 or higher with the following build options:
+LXD requires LXC 4.0.0 or higher with the following build options:
 -->
-LXD は以下のビルドオプションでビルドされた LXC 3.0.0 以上を必要とします。
+LXD は以下のビルドオプションでビルドされた LXC 4.0.0 以上を必要とします。
 
 <!--
  * apparmor (if using LXD's apparmor support)

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -499,6 +499,11 @@ definitions:
           source: /1.0/instances/c1
         type: object
         x-go-name: Metadata
+      project:
+        description: Project the event belongs to.
+        example: default
+        type: string
+        x-go-name: Project
       timestamp:
         description: Time at which the event was sent
         example: "2021-02-24T19:00:45.452649098-05:00"
@@ -1709,6 +1714,11 @@ definitions:
         example: ubuntu/20.04
         type: string
         x-go-name: Alias
+      allow_inconsistent:
+        description: Whether to ignore errors when copying (e.g. for volatile files)
+        example: false
+        type: boolean
+        x-go-name: AllowInconsistent
       base-image:
         description: Base image fingerprint (for faster migration)
         example: ed56997f7c5b48e8d78986d2467a26109be6fb9f2d92e8c7b08eb8b6cec7629a
@@ -7507,7 +7517,7 @@ paths:
       tags:
       - instances
     get:
-      description: Gets a specific instance.
+      description: Gets a specific instance (basic struct).
       operationId: instance_get
       parameters:
       - description: Project name
@@ -8804,6 +8814,49 @@ paths:
         "500":
           $ref: '#/responses/InternalServerError'
       summary: Change the state
+      tags:
+      - instances
+  /1.0/instances/{name}?recursion=1:
+    get:
+      description: |-
+        Gets a specific instance (full struct).
+
+        recursion=1 also includes information about state, snapshots and backups.
+      operationId: instance_get_recursion1
+      parameters:
+      - description: Project name
+        example: default
+        in: query
+        name: project
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Instance
+          schema:
+            description: Sync response
+            properties:
+              metadata:
+                $ref: '#/definitions/Instance'
+              status:
+                description: Status description
+                example: Success
+                type: string
+              status_code:
+                description: Status code
+                example: 200
+                type: integer
+              type:
+                description: Response type
+                example: sync
+                type: string
+            type: object
+        "403":
+          $ref: '#/responses/Forbidden'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Get the instance
       tags:
       - instances
   /1.0/instances?recursion=1:

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -395,7 +395,7 @@ ceph.osd.data\_pool\_name     | string                        | -               
 ceph.osd.force\_reuse         | bool                          | false                                   | 別の LXD インスタンスで既に使用されている osd ストレージプールの使用を強制するか <!-- Force using an osd storage pool that is already in use by another LXD instance -->
 ceph.osd.pg\_num              | string                        | 32                                      | osd ストレージプール用の placement グループの数 <!-- Number of placement groups for the osd storage pool -->
 ceph.osd.pool\_name           | string                        | プールの名前 <!-- name of the pool -->  | osd ストレージプールの名前 <!-- Name of the osd storage pool -->
-ceph.rbd.clone\_copy          | string                        | true                                    | フルのデータセットコピーではなく RBD のライトウェイトクローンを使うかどうか <!-- Whether to use RBD lightweight clones rather than full dataset copies -->
+ceph.rbd.clone\_copy          | bool                          | true                                    | フルのデータセットコピーではなく RBD のライトウェイトクローンを使うかどうか <!-- Whether to use RBD lightweight clones rather than full dataset copies -->
 ceph.rbd.du                   | bool                          | true                                    | 停止したインスタンスのディスク使用データを取得するのに rbd du を使用するかどうか <!-- Whether to use rbd du to obtain disk usage data for stopped instances. -->
 ceph.rbd.features             | string                        | layering                                | ボリュームで有効にする RBD の機能のカンマ区切りリスト <!-- Comma separate list of RBD features to enable on the volumes -->
 ceph.user.name                | string                        | admin                                   | ストレージプールとボリュームの作成に使用する ceph ユーザー <!-- The ceph user to use when creating storage pools and volumes -->


### PR DESCRIPTION
* [原文の変更](https://github.com/lxc-jp/lxd-ja/compare/upstream-20211210...upstream-20220114) では doc/ の上の contribution.md や README.md をインクルードするように変更されているのですが、日本語のほうではインクルードの仕組みがあるかよくわかってないのでそのままにしています。
* 原文では表にCSSのクラスを追加していますが、こちらも日本語版では対応してないです。

Signed-off-by: Hiroaki Nakamura <hnakamur@gmail.com>